### PR TITLE
Add automatic coloring settings

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -22,6 +22,21 @@
         "name": "Duration",
         "hint": "How long (in ms) should the token flashing be for all effects (Default 500 ms, this will scaled if you toggle on settings that scale duration)"
       },
+      "auto-coloring": {
+        "ring": {
+          "name": "Token Ring Color",
+          "hint": "Select if the module should change the dynamic token ring color"
+        },
+        "background": {
+          "name": "Token Background Color",
+          "hint": "Select if the module should change the dynamic token background color"
+        },
+        "choices": {
+          "unchanged": "Unchanged",
+          "health": "Health-Based",
+          "disposition": "Disposition"
+        }
+      },
       "": {
         "name": "",
         "hint": ""

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -22,6 +22,21 @@
         "name": "Czas trwania",
         "hint": "Jak długo (w ms) powinien migać token dla wszystkich efektów (domyślnie 500 ms, będzie to skalowane, jeśli włączysz ustawienia skalujące czas trwania)."
       },
+      "auto-coloring": {
+        "ring": {
+          "name": "Token Ring Color",
+          "hint": "Select if the module should change the dynamic token ring color"
+        },
+        "background": {
+          "name": "Token Background Color",
+          "hint": "Select if the module should change the dynamic token background color"
+        },
+        "choices": {
+          "unchanged": "Unchanged",
+          "health": "Health-Based",
+          "disposition": "Disposition"
+        }
+      },
       "": {
         "name": "",
         "hint": ""

--- a/module.json
+++ b/module.json
@@ -17,7 +17,16 @@
   "relationships": {
     "systems": [
     ],
-    "requires": []
+    "requires": [
+      {
+        "id": "lib-wrapper",
+        "type": "module",
+        "compatibility": {
+            "minimum": "1.0.0.0",
+            "verified": "1.12.14.0"
+        }
+      }
+    ]
   },
   "esmodules": ["scripts/module.js"],
   "languages": [

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,12 +1,13 @@
 // Import necessary modules and constants
 import { CONDITIONS, MODULE_ID } from "./misc.js";
 import { registerSettings } from "./settings.js";
-import { getHealingInfo } from "./systemCompatability.js";
+import { getHealingInfo, getHealthLevel, updateHasAllianceChange } from "./systemCompatability.js";
 
 // Define color constants
 const COLORS = {
   GREEN: "#ADFF2F",
   RED: "#FF0000",
+  YELLOW: "#FFFF00",
   PURPLE: "#9370DB",
   WHITE: "#FFFFFF",
   DEEPSKYBLUE: "#00BFFF",
@@ -14,8 +15,11 @@ const COLORS = {
   PINK: "#FF69B4",
 };
 
-// Initialize module settings
-Hooks.once("init", registerSettings);
+// Initialize module settings and ring color wrapper
+Hooks.once("init", () => {
+  registerSettings();
+  registerRingColorsWrapper();
+});
 
 // Set up main functionality when Foundry VTT is ready
 Hooks.once("ready", async () => {
@@ -23,15 +27,33 @@ Hooks.once("ready", async () => {
   Hooks.on("preUpdateActor", async (actor, update, status, _userID) => {
     if (!status.diff) return;
     const { isHeal, dmg, maxHP } = getHealingInfo(actor, update, status);
-    if (isHeal === undefined) return;
-    const token = canvas.tokens.placeables.find((t) => t.actor.id === actor.id);
-    const color = isHeal ? COLORS.GREEN : COLORS.RED;
-    const situation = isHeal ? "heal" : "damage";
-    await flashColor(
-      token,
-      color,
-      getAnimationChanges(situation, { dmg, maxHP })
-    );
+    if (isHeal !== undefined) {
+      const token = canvas.tokens.placeables.find((t) => t.actor.id === actor.id);
+      if (!token) return;
+      // Update health level flag for the module so the Ring color can be determined before the actual update
+      await token.document.setFlag(MODULE_ID, "tokenHealthLevel", getHealthLevel(actor, update));
+      // Force updating of the ring elements including background before flashing
+      if (token.document.ring?.enabled) token.ring.configureVisuals();
+      // Flash!
+      const color = isHeal ? COLORS.GREEN : COLORS.RED;
+      const situation = isHeal ? "heal" : "damage";
+      await flashColor(
+        token,
+        color,
+        getAnimationChanges(situation, { dmg, maxHP })
+      );
+    }
+  });
+
+  Hooks.on("updateActor", (actor, update, status, _userID) => {
+    if (!status.diff) return;
+    // Cause a manual token ring update if alliance changed via system, so it picks up disposition
+    // If the system-specific part is not implemented, it will simply synch up on the next regular update.
+    if (updateHasAllianceChange(actor, update)) {
+      const token = canvas.tokens.placeables.find((t) => t.actor.id === actor.id);
+      if (!token) return;
+      if (token.document.ring?.enabled) token.ring.configureVisuals();
+    }
   });
 
   // Handle token targeting
@@ -128,3 +150,58 @@ const effects = Object.freeze({
   BKG_WAVE: 0x08,
   INVISIBILITY: 0x10,
 });
+
+/**
+ * Calculate the color representing the current health level.
+ * To scale from red to green, we apply the health level to the first third of the hue in HSV space.
+ * @param {number} level - Health level from 0 (worst) to 1 (best).
+ * @returns {Color}
+ */
+function getColorForHealthLevel(level) {
+  return Color.fromHSV([level / 3.0, 1.0, 1.0]);
+}
+
+/**
+ * Override getRingColors on the Token class, which returns an empty object by default
+ * and falls through to fallbacks. Note that changing the returns of that function does
+ * not cause a rendering update; calling configureVisuals() can do that.
+ */
+function registerRingColorsWrapper() {
+  try {
+    libWrapper.register(MODULE_ID, 'CONFIG.Token.objectClass.prototype.getRingColors', function () {
+      let ringColor = undefined;
+      let backgroundColor = undefined;
+      const ringSetting = game.settings.get(MODULE_ID, "auto-coloring.ring");
+      const backgroundSetting = game.settings.get(MODULE_ID, "auto-coloring.background");
+
+      if (ringSetting === "health" || backgroundSetting === "health") {
+        const level = this.document.getFlag(MODULE_ID, "tokenHealthLevel") ?? getHealthLevel(this.actor);
+        const healthColor = getColorForHealthLevel(level);
+        if (ringSetting === "health")
+          ringColor = healthColor;
+        if (backgroundSetting === "health")
+          backgroundColor = healthColor;
+      }
+
+      if (ringSetting === "disposition" || backgroundSetting === "disposition") {
+        let dispositionColor = undefined;
+        switch (this.document.disposition) {
+          case CONST.TOKEN_DISPOSITIONS.FRIENDLY: dispositionColor = COLORS.GREEN; break;
+          case CONST.TOKEN_DISPOSITIONS.NEUTRAL: dispositionColor = COLORS.YELLOW; break;
+          case CONST.TOKEN_DISPOSITIONS.HOSTILE: dispositionColor = COLORS.RED; break;
+        }
+        if (ringSetting === "disposition")
+          ringColor = dispositionColor;
+        if (backgroundSetting === "disposition")
+          backgroundColor = dispositionColor;
+      }
+
+      return {
+        ring: ringColor,
+        background: backgroundColor,
+      };
+    }, 'OVERRIDE');
+  } catch {
+    ui.notifications.error("REDY: Another module is already overriding token ring colors!");
+  }
+}

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -50,4 +50,29 @@ export function registerSettings() {
     },
     type: Number,
   });
+  const autoColoringChoices = {
+    "unchanged": game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.choices.unchanged"),
+    "health": game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.choices.health"),
+    "disposition": game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.choices.disposition"),
+  }
+  game.settings.register(MODULE_ID, "auto-coloring.ring", {
+    name: game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.ring.name"),
+    hint: game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.ring.hint"),
+    scope: "client",
+    config: true,
+    default: "unchanged",
+    type: String,
+    requiresReload: true,
+    choices: autoColoringChoices,
+  });
+  game.settings.register(MODULE_ID, "auto-coloring.background", {
+    name: game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.background.name"),
+    hint: game.i18n.localize(MODULE_ID + ".module-settings.auto-coloring.background.hint"),
+    scope: "client",
+    config: true,
+    default: "unchanged",
+    type: String,
+    requiresReload: true,
+    choices: autoColoringChoices,
+  });
 }


### PR DESCRIPTION
This adds two new automatic coloring settings for dynamic token rings to the module:
- Token Ring Coloring
- Token Background Coloring

For both of these, it offers choices:
- Unchanged: Use the default color and effectively disable this setting.
- Health-Based: Interpolate the color from red to green as health goes up.
- Disposition: Apply a color based on the token disposition: green for friendly, yellow for neutral, red for hostile.

In order to override the token ring color function that Foundry provides and expects to have overridden, libWrapper has been added as a dependency. Should some other module attempt to do the same an error will be presented for the user to be aware of the conflict.