### PR TITLE
Fix multiplayer health flashing

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,6 +28,7 @@
     ]
   },
   "esmodules": ["scripts/module.js"],
+  "socket": true,
   "languages": [
     {
       "lang": "en",


### PR DESCRIPTION
Since the preUpdateActor hook only triggers on the originating client, we need to use a custom socket for the module and broadcast our flashing instructions to other clients.

This should close #34.