### PR TITLE
More fixes

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -44,9 +44,7 @@ Hooks.once("ready", async () => {
         // Trigger other clients now
         game.socket.emit(`module.${MODULE_ID}`, {type: "tokenHealthUpdate", payload: args});
       };
-      for (const token of canvas.tokens.placeables.filter(
-        (t) => t.actor.uuid === actor.uuid
-      )) {
+      for (const token of actor.getActiveTokens()) {
         processToken(token);
       }
     }
@@ -57,9 +55,7 @@ Hooks.once("ready", async () => {
     // Cause a manual token ring update if alliance changed via system, so it picks up disposition
     // If the system-specific part is not implemented, it will simply synch up on the next regular update.
     if (updateHasAllianceChange(actor, update)) {
-      for (const token of canvas.tokens.placeables.filter(
-        (t) => t.actor.uuid === actor.uuid
-      )) {
+      for (const token of actor.getActiveTokens()) {
         if (token.document.ring?.enabled) token.ring.configureVisuals();
       }
     }

--- a/scripts/systemCompatability.js
+++ b/scripts/systemCompatability.js
@@ -20,7 +20,10 @@ export function getHealingInfo(actor, update, status) {
   const dmgTaken =
     foundry.utils.getProperty(status, keys.statusDamagePath) ??
     currentHP - updateHP;
-  if (updateHP === undefined || updateHP === currentHP || !dmgTaken)
+  // Slight hack to check for the actors adjustment since that seems to send only the new HP and adjustment update.
+  // Do not trigger on those.
+  const adjustmentChange = foundry.utils.getProperty(update, keys.adjustmentPath) !== undefined;
+  if (updateHP === undefined || updateHP === currentHP || !dmgTaken || adjustmentChange)
     return { isHeal: undefined, dmg: undefined, maxHP: undefined };
   const maxHP = foundry.utils.getProperty(actor, keys.hpMaxPath);
   return {
@@ -111,6 +114,7 @@ function getSystemKeys(actor) {
         zeroIsBad: true,
         statusDamagePath: "damageTaken",
         alliancePath: "system.details.alliance",
+        adjustmentPath: "system.attributes.adjustment",
       };
     case "hexxen-1733":
       return {

--- a/scripts/systemCompatability.js
+++ b/scripts/systemCompatability.js
@@ -20,7 +20,7 @@ export function getHealingInfo(actor, update, status) {
   const dmgTaken =
     foundry.utils.getProperty(status, keys.statusDamagePath) ??
     currentHP - updateHP;
-  if (updateHP === undefined || !dmgTaken)
+  if (updateHP === undefined || updateHP === currentHP || !dmgTaken)
     return { isHeal: undefined, dmg: undefined, maxHP: undefined };
   const maxHP = foundry.utils.getProperty(actor, keys.hpMaxPath);
   return {


### PR DESCRIPTION
Thanks to shemetz for reporting these.
Fixes flashing on 0 hp heals and adjustment changes, and stops errors on actorless tokens.