### PR TITLE
Add health color target setting

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -36,6 +36,15 @@
           "health": "Gesundheitsbasiert",
           "disposition": "Gesinnung"
         },
+        "health-targets": {
+          "name": "Gesundheitsbasierte Färbung für",
+          "hint": "Wenn gesundheitsbasierte Färbung aktiviert ist, trifft diese nur bei folgender Gesinnung gezeigt.",
+          "all": "Alle",
+          "friendly": "Freundlich",
+          "non-friendly": "Nicht Freundlich",
+          "hostile": "Feindlich",
+          "non-hostile": "Nicht Feindlich"
+        },
         "percent-color": {
           "name": "Faktor der automatischen Färbung",
           "hint": "Wie stark die Sättigung der automatischen Färbung ausfallen soll"

--- a/languages/en.json
+++ b/languages/en.json
@@ -36,6 +36,15 @@
           "health": "Health-Based",
           "disposition": "Disposition"
         },
+        "health-targets": {
+          "name": "Health-Based Token Applies To",
+          "hint": "If Health-Based auto coloring is enabled, this can be set to only apply to actors by their disposition.",
+          "all": "All",
+          "friendly": "Friendly",
+          "non-friendly": "Non-Friendly",
+          "hostile": "Hostile",
+          "non-hostile": "Non-Hostile"
+        },
         "percent-color": {
           "name": "Token Auto Color Percentage",
           "hint": "How much should the saturation of the autocoloring be"

--- a/scripts/autoColorRing.js
+++ b/scripts/autoColorRing.js
@@ -1,6 +1,28 @@
 import { COLORS, MODULE_ID } from "./misc.js";
 import { getHealthLevel } from "./systemCompatability.js";
 
+/**
+ * Check if the token is a valid disposition for our health target setting.
+ * @param {Object} Token instance
+ * @returns {boolean} If the token should be colored
+ */
+function getValidHealthTarget(token) {
+  const healthTargetsSetting = game.settings.get(MODULE_ID, "auto-coloring.health-targets");
+  if (token.document.disposition == CONST.TOKEN_DISPOSITIONS.FRIENDLY &&
+    (healthTargetsSetting === "non-friendly" || healthTargetsSetting === "hostile"))
+    return false;
+  if (token.document.disposition == CONST.TOKEN_DISPOSITIONS.HOSTILE &&
+    (healthTargetsSetting === "non-hostile" || healthTargetsSetting === "friendly"))
+    return false;
+  if (token.document.disposition == CONST.TOKEN_DISPOSITIONS.NEUTRAL &&
+    (healthTargetsSetting === "hostile" || healthTargetsSetting === "friendly"))
+    return false;
+  if (token.document.disposition == CONST.TOKEN_DISPOSITIONS.SECRET &&
+    healthTargetsSetting !== "all")
+    return false;
+  return true;
+}
+
 export function autoColorRing() {
   let ringColor = this.document.ring.colors.ring;
   let backgroundColor = this.document.ring.colors.background;
@@ -16,8 +38,9 @@ export function autoColorRing() {
       getHealthLevel(this.actor);
     if (!isNaN(level)) {
       const healthColor = getColorForHealthLevel(level);
-      if (ringSetting === "health") ringColor = healthColor;
-      if (backgroundSetting === "health") backgroundColor = healthColor;
+      const valid = getValidHealthTarget(this);
+      if (ringSetting === "health" && valid) ringColor = healthColor;
+      if (backgroundSetting === "health" && valid) backgroundColor = healthColor;
     }
   }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -91,6 +91,36 @@ export function registerSettings() {
     requiresReload: true,
     choices: autoColoringChoices,
   });
+  game.settings.register(MODULE_ID, "auto-coloring.health-targets", {
+    name: game.i18n.localize(
+      MODULE_ID + ".module-settings.auto-coloring.health-targets.name"
+    ),
+    hint: game.i18n.localize(
+      MODULE_ID + ".module-settings.auto-coloring.health-targets.hint"
+    ),
+    scope: "client",
+    config: true,
+    default: "all",
+    type: String,
+    requiresReload: true,
+    choices: {
+      "all": game.i18n.localize(
+        MODULE_ID + ".module-settings.auto-coloring.health-targets.all"
+      ),
+      "friendly": game.i18n.localize(
+        MODULE_ID + ".module-settings.auto-coloring.health-targets.friendly"
+      ),
+      "non-friendly": game.i18n.localize(
+        MODULE_ID + ".module-settings.auto-coloring.health-targets.non-friendly"
+      ),
+      "hostile": game.i18n.localize(
+        MODULE_ID + ".module-settings.auto-coloring.health-targets.hostile"
+      ),
+      "non-hostile": game.i18n.localize(
+        MODULE_ID + ".module-settings.auto-coloring.health-targets.non-hostile"
+      )
+    },
+  });
   game.settings.register(MODULE_ID, "auto-coloring.percent-color", {
     name: game.i18n.localize(
       MODULE_ID + ".module-settings.auto-coloring.percent-color.name"
@@ -135,7 +165,7 @@ export function registerSettings() {
     default: COLORS.DEEPSKYBLUE,
     type: new foundry.data.fields.ColorField()
   });
-  
+
   game.settings.register(MODULE_ID, "colors.status.positive", {
     name: game.i18n.localize(MODULE_ID + ".module-settings.colors.status.positive.name"),
     hint: game.i18n.localize(MODULE_ID + ".module-settings.colors.status.positive.hint"),


### PR DESCRIPTION
This allows customizing what tokens health based coloring is applied to, selectable by disposition.
Options are:
- Friendly
- Non-Friendly
- Hostile
- Non-Hostile