### PR TITLE
Add support for Dungeon Crawl Classics (DCC) system

### DIFF
--- a/scripts/systemCompatibility.js
+++ b/scripts/systemCompatibility.js
@@ -104,6 +104,12 @@ function getSystemKeys(actor) {
         hpMaxPath: "system.derivedStats.hp.max",
         zeroIsBad: true,
       };
+    case "dcc":
+      return {
+        hpPath: "system.attributes.hp.value",
+        hpMaxPath: "system.attributes.hp.max",
+        zeroIsBad: true,
+      };
     case "daggerheart":
       return {
         hpPath: "system.resources.hitPoints.value",


### PR DESCRIPTION
## Summary
- Adds DCC to the list of supported game systems in `systemCompatibility.js`
- Maps DCC's HP paths to enable reactive token rings for health tracking
- Follows the existing pattern used by other systems like D&D 4e

## Details
The DCC system stores HP data at:
- Current HP: `system.attributes.hp.value`
- Max HP: `system.attributes.hp.max`
- Zero is bad: `true` (lower HP values indicate worse health)

This implementation enables the Reactive Token Rings module to:
- Track health changes on DCC tokens
- Display appropriate ring colors based on health levels
- React to healing and damage events