### PR TITLE
Add SF2e system support

### DIFF
--- a/scripts/systemCompatibility.js
+++ b/scripts/systemCompatibility.js
@@ -138,6 +138,7 @@ function getSystemKeys(actor) {
     case "dungeonworld":
     case "pf1":
     case "pf2e":
+    case "sf2e":
       return {
         hpPath: "system.attributes.hp.value",
         hpMaxPath: "system.attributes.hp.max",


### PR DESCRIPTION
Since the systems work mostly the same behind the scenes, it should be as simple as adding its ID to the compatibility function.